### PR TITLE
chore: normalize line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.csv text eol=lf


### PR DESCRIPTION
Ensure consistent LF endings for SQL/workflows/CSV on Windows.
